### PR TITLE
Add a .dockstore.yml for automatic synchronization with Dockstore and GitHub

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,30 @@
+version: 1.2
+workflows:
+  - name: FragPipe_PeptideProphet
+    subclass: CWL
+    primaryDescriptorPath: /FragPipe-Convert-Identify-PeptideProphet/fragpipe-convert-identify-peptideprophet.cwl
+    authors:
+      - name: Dave Roberson
+        email: david.roberson@sevenbridges.com
+  - name: FragPipe_Report
+    subclass: CWL
+    primaryDescriptorPath: /FragPipe-Filter-Quant-Report/fragpipe-filter-quant-report.cwl
+    authors:
+      - name: Dave Roberson
+        email: david.roberson@sevenbridges.com
+  - name: FragPipe_ProteinProphet
+    subclass: CWL
+    primaryDescriptorPath: /FragPipe-ProteinProphet/fragpipe-proteinprophet.cwl
+    authors:
+      - name: Dave Roberson
+        email: david.roberson@sevenbridges.com
+      - name: Felipe da Veiga Leprevost
+        email: felipevl@umich.edu
+  - name: FragPipe_TMT_QC
+    subclass: CWL
+    primaryDescriptorPath: /FragPipe-TMT-Integrator-and-QC/fragpipe-tmt-integrator-and-qc.cwl
+    authors:
+      - name: Dave Roberson
+        email: david.roberson@sevenbridges.com
+      - name: Felipe da Veiga Leprevost
+        email: felipevl@umich.edu


### PR DESCRIPTION
If this is merged, and if this repository installs [the Dockstore GitHub App](https://github.com/apps/dockstore/), then four unpublished entries will be created on Dockstore. Then, someone who has access to this repository on GitHub can log into Dockstore, and publish entries to make them public.

More information here: https://docs.dockstore.org/en/stable/getting-started/dockstore-workflows.html

Due to how GitHub works, you will might need to make one additional commit of any kind **after** merging this PR before the entries show up in GitHub. But all subsequent commits will be synchronized between Dockstore and GitHub automatically.